### PR TITLE
Add uninstall step and document system touchpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,16 @@ just-aliases.zsh   # shell integration
 ```
 
 See `documents/high-level-idea.md` for the broader design goals.
+
+## Uninstall
+
+To remove all files that just-aliases creates on your system run:
+
+```bash
+just uninstall
+```
+
+This deletes the custom oh-my-zsh scripts, the global installation at
+`~/.just-aliases`, the configuration directory and any snippets added to your
+`~/.zshrc`.  See `documents/integration-points.md` for a complete list of
+touchpoints.

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
     - managing tmux sessions/windows...maybe we manage them and switch automatically
     - checking some cron jobs or something that automatically update a terminal if its become stale... if we didn't do anything for several minutes it will show a notification that we will have something to do there
     - loom go can keep track of events that are queued up and that we wanna visit (e.g. loom go next)
-        - loom go can figure out context of what it wants to do
+    - loom go can figure out context of what it wants to do
 
 - we want to have some way of grepping for todos in all the files in the directory
     - this means we need a pattern for all files in the directory that may have todos
@@ -31,3 +31,8 @@
     - opening project test coverage reports
     - opening project dependency/license reports
     - opening project security scan reports
+
+## touchpoint tracking
+- implement a schema describing all integration points (files, directories, zshrc snippets)
+- expose a command that lists these touchpoints
+- validate that `uninstall` removes everything defined in the schema

--- a/documents/integration-points.md
+++ b/documents/integration-points.md
@@ -1,0 +1,16 @@
+# System Integration Points
+
+This document lists the files and configuration that *just-aliases* touches on a macOS system.
+It is useful for auditing or completely removing the tool.
+
+## Files and locations
+
+- `~/.oh-my-zsh/custom/jazzydog-labs/` – copies of the `bootstrap/*.zsh` scripts are placed here by `setup-modular-loading.sh`.
+- Snippet inserted into `~/.zshrc` between `#START: Load all custom modular scripts` and `#END: Load all custom modular scripts`. This loads every script from the directory above.
+- Lines sourcing `just-aliases.zsh` may be appended to `~/.zshrc` during manual setup.
+- `~/.config/jazzydog-labs/.config.yaml` – configuration file copied from the repo.
+- `~/.just-aliases/` – global installation with generated scripts and a `justfile`.
+
+## Removal
+
+Run `just uninstall` (or execute `./uninstall.sh`) to remove all of the above. It deletes the directories, removes the snippet from `~/.zshrc`, and cleans up any line that sources `just-aliases.zsh`.

--- a/justfile
+++ b/justfile
@@ -162,4 +162,8 @@ global-all:
 
 global-help:
     @echo "🌍 Help using global installation..."
-    just -f ~/.just-aliases/justfile help 
+    just -f ~/.just-aliases/justfile help
+
+# Remove all system touchpoints installed by just-aliases
+uninstall:
+    @./uninstall.sh

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Remove all just-aliases integration touchpoints from the system
+
+set -e
+
+CUSTOM_DIR="$HOME/.oh-my-zsh/custom/jazzydog-labs"
+CONFIG_DIR="$HOME/.config/jazzydog-labs"
+GLOBAL_DIR="$HOME/.just-aliases"
+ZSHRC="$HOME/.zshrc"
+
+# Remove copied bootstrap scripts
+if [ -d "$CUSTOM_DIR" ]; then
+    rm -rf "$CUSTOM_DIR"
+    echo "Removed $CUSTOM_DIR"
+fi
+
+# Remove modular loading snippet from .zshrc
+if grep -q "#START: Load all custom modular scripts" "$ZSHRC"; then
+    sed -i '' '/#START: Load all custom modular scripts/,/#END: Load all custom modular scripts/d' "$ZSHRC"
+    echo "Removed modular loading code from $ZSHRC"
+fi
+
+# Remove any line sourcing just-aliases.zsh
+if grep -q "just-aliases.zsh" "$ZSHRC"; then
+    sed -i '' '/just-aliases.zsh/d' "$ZSHRC"
+    echo "Removed just-aliases source line from $ZSHRC"
+fi
+
+# Remove global installation
+if [ -d "$GLOBAL_DIR" ]; then
+    rm -rf "$GLOBAL_DIR"
+    echo "Removed $GLOBAL_DIR"
+fi
+
+# Remove config directory
+if [ -d "$CONFIG_DIR" ]; then
+    rm -rf "$CONFIG_DIR"
+    echo "Removed $CONFIG_DIR"
+fi
+
+echo "✅ just-aliases touchpoints removed"


### PR DESCRIPTION
## Summary
- document integration points with the host system
- add an `uninstall` script and justfile command to remove them
- mention uninstall instructions in the README
- plan next steps for touchpoint schema

## Testing
- `bash -n uninstall.sh`


------
https://chatgpt.com/codex/tasks/task_e_686abf9b245c83239351233e3cb2b198